### PR TITLE
Level 01 : Adding a section in Global Configuration page

### DIFF
--- a/src/main/java/io/jenkins/plugins/nevin/OnboardingPlugin.java
+++ b/src/main/java/io/jenkins/plugins/nevin/OnboardingPlugin.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.nevin;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import org.kohsuke.stapler.DataBoundSetter;
+
+@Extension
+public class OnboardingPlugin extends GlobalConfiguration {
+
+    private String name;
+    private String description;
+
+    public OnboardingPlugin() {
+        load();
+    }
+
+    public static OnboardingPlugin get() {
+        return GlobalConfiguration.all().get(OnboardingPlugin.class);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = name;
+        save();
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @DataBoundSetter
+    public void setDescription(String description) {
+        this.description = description;
+        save();
+    }
+}
+
+

--- a/src/main/resources/io/jenkins/plugins/nevin/OnboardingPlugin/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/nevin/OnboardingPlugin/config.jelly
@@ -3,13 +3,6 @@
     <f:section title="Onboarding Plugin">
         <f:entry title="Name" field="name">
             <f:textbox />
-            <f:validation-error>
-                <st:if test="instance/validationMessages/name">
-                    <f:repeat value="${instance/validationMessages/name}" var="err">
-                        <f:message>${err}</f:message>
-                    </f:repeat>
-                </st:if>
-            </f:validation-error>
         </f:entry>
         <f:entry title="Description" field="description">
             <f:textarea />

--- a/src/main/resources/io/jenkins/plugins/nevin/OnboardingPlugin/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/nevin/OnboardingPlugin/config.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:section title="Onboarding Plugin">
+        <f:entry title="Name" field="name">
+            <f:textbox />
+            <f:validation-error>
+                <st:if test="instance/validationMessages/name">
+                    <f:repeat value="${instance/validationMessages/name}" var="err">
+                        <f:message>${err}</f:message>
+                    </f:repeat>
+                </st:if>
+            </f:validation-error>
+        </f:entry>
+        <f:entry title="Description" field="description">
+            <f:textarea />
+        </f:entry>
+    </f:section>
+</j:jelly>


### PR DESCRIPTION
I have added a new Section in Global Configurations page  (`http://localhost:8080/jenkins/manage/configure`)

<img width="1488" alt="image" src="https://github.com/nevingeorgesunny/demo-jenkins-plugin/assets/9782354/4aa9dfff-b3f7-4fc7-9e1a-20a15e86b44f">

It can take in a `Name` and  `Description ` fields